### PR TITLE
Ignore Jupyter Notebook files in 'Languages'

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.ipynb linguist-vendored


### PR DESCRIPTION
this `.gitattributes` file should ignore all .ipynb files, so the library's language will appear as Python
<https://proandroiddev.com/removing-noise-from-your-github-language-stats-e96113f8183d>